### PR TITLE
Add .env file support for easier configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# NanoCoder Configuration Example / NanoCoder 配置示例
+# Copy this file to .env and fill in your values / 复制此文件为 .env 并填入你的配置
+
+# =============================================================================
+# API Key (Required) / API 密钥（必填）
+# =============================================================================
+NANOCODER_API_KEY=your-api-key-here
+# Alternatively use: OPENAI_API_KEY or DEEPSEEK_API_KEY / 或使用: OPENAI_API_KEY / DEEPSEEK_API_KEY
+
+# =============================================================================
+# Model Configuration / 模型配置
+# =============================================================================
+# Model name (Optional, default: gpt-4o) / 模型名称（可选，默认 gpt-4o）
+NANOCODER_MODEL=gpt-4o
+
+# API Base URL (Optional) / API 地址（可选）
+OPENAI_BASE_URL=https://api.openai.com/v1
+# Alternatively use: NANOCODER_BASE_URL / 或使用: NANOCODER_BASE_URL
+
+# =============================================================================
+# Generation Parameters / 生成参数
+# =============================================================================
+# Max output tokens (Optional, default: 4096) / 最大输出 token 数（可选，默认 4096）
+NANOCODER_MAX_TOKENS=4096
+
+# Temperature (Optional, default: 0) / 温度参数（可选，默认 0）
+NANOCODER_TEMPERATURE=0
+
+# Max context length (Optional, default: 128000) / 最大上下文长度（可选，默认 128000）
+NANOCODER_MAX_CONTEXT=128000

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ Pick your model — any OpenAI-compatible API works:
 # Kimi K2.5
 export OPENAI_API_KEY=your-key OPENAI_BASE_URL=https://api.moonshot.ai/v1
 nanocoder -m kimi-k2.5
+```
+
+Or use a `.env` file for configuration (see `.env.example`):
+
+```bash
+cp .env.example .env
+# Edit .env with your settings
+nanocoder
 
 # Claude Opus 4.6 (via OpenRouter)
 export OPENAI_API_KEY=your-key OPENAI_BASE_URL=https://openrouter.ai/api/v1

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,6 +60,14 @@ pip install nanocoderagent
 # Kimi K2.5
 export OPENAI_API_KEY=你的key OPENAI_BASE_URL=https://api.moonshot.ai/v1
 nanocoder -m kimi-k2.5
+```
+
+或使用 `.env` 文件配置（参考 `.env.example`）：
+
+```bash
+cp .env.example .env
+# 编辑 .env 填入你的配置
+nanocoder
 
 # Claude Opus 4.6（通过 OpenRouter）
 export OPENAI_API_KEY=你的key OPENAI_BASE_URL=https://openrouter.ai/api/v1

--- a/nanocoder/config.py
+++ b/nanocoder/config.py
@@ -2,6 +2,25 @@
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
+
+# Load .env file if exists
+try:
+    from dotenv import load_dotenv
+    # Load from current directory and parent directories
+    load_dotenv()
+    # Also try to load from project root if in subdirectory
+    project_root = Path.cwd()
+    for _ in range(3):  # Search up to 3 levels
+        env_file = project_root / ".env"
+        if env_file.exists():
+            load_dotenv(env_file)
+            break
+        if project_root.parent == project_root:
+            break
+        project_root = project_root.parent
+except ImportError:
+    pass  # python-dotenv not installed, skip
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "openai>=1.0",
     "rich>=13.0",
     "prompt_toolkit>=3.0",
+    "python-dotenv>=1.0",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Motivation / 动机

Using command-line arguments to pass API keys and model settings can be inconvenient during testing and daily use. This PR adds support for reading configuration from `.env` files, making it easier to manage settings without repeatedly setting environment variables.

在测试和日常使用中，通过命令行参数传入 API 密钥和模型设置略有不便。本 PR 添加了从 `.env` 文件读取配置的功能，无需重复设置环境变量即可轻松管理配置。

## Changes / 变更内容

- Add `python-dotenv` dependency in `pyproject.toml`
- Modify `nanocoder/config.py` to auto-load `.env` files (with graceful fallback if dotenv not installed)
- Add `.env.example` with bilingual comments (Chinese/English)
- Update `README.md` and `README_CN.md` with `.env` usage instructions

## Usage / 使用方法

```bash
cp .env.example .env
# Edit .env with your API key and model settings
nanocoder