### PR TITLE
Fix resume functionality for model

### DIFF
--- a/nanocoder/cli.py
+++ b/nanocoder/cli.py
@@ -75,6 +75,8 @@ def main():
         loaded = load_session(args.resume)
         if loaded:
             agent.messages, loaded_model = loaded
+            agent.llm.model = loaded_model
+            config.model = loaded_model
             console.print(f"[green]Resumed session: {args.resume}[/green]")
         else:
             console.print(f"[red]Session '{args.resume}' not found.[/red]")


### PR DESCRIPTION
Currently, resuming from session doesn't set model properly. For example, create a session with model="deepseek-chat", save the session, and resume from the saved session later, the model will be the default "gpt-4o" instead of "deepseek-chat".

Fix this by set model info properly when resuming from a saved session.