### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/corecoder/cli.py
+++ b/corecoder/cli.py
@@ -12,7 +12,7 @@ from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
 
 from .agent import Agent
-from .llm import LLM
+from .llm import LLM, LiteLLM
 from .config import Config
 from .session import save_session, load_session, list_sessions
 from . import __version__
@@ -62,7 +62,8 @@ def main():
         )
         sys.exit(1)
 
-    llm = LLM(
+    llm_cls = LiteLLM if config.provider == "litellm" else LLM
+    llm = llm_cls(
         model=config.model,
         api_key=config.api_key,
         base_url=config.base_url,

--- a/corecoder/config.py
+++ b/corecoder/config.py
@@ -33,6 +33,7 @@ class Config:
     max_tokens: int = 4096
     temperature: float = 0.0
     max_context_tokens: int = 128_000
+    provider: str = "openai"
 
     @classmethod
     def from_env(cls) -> "Config":
@@ -52,4 +53,5 @@ class Config:
             max_tokens=int(os.getenv("CORECODER_MAX_TOKENS", "4096")),
             temperature=float(os.getenv("CORECODER_TEMPERATURE", "0")),
             max_context_tokens=int(os.getenv("CORECODER_MAX_CONTEXT", "128000")),
+            provider=os.getenv("CORECODER_PROVIDER", "openai"),
         )

--- a/corecoder/llm.py
+++ b/corecoder/llm.py
@@ -3,6 +3,10 @@
 Since most providers (DeepSeek, Qwen, Kimi, GLM, Ollama, etc.) expose an
 OpenAI-compatible endpoint, we just use the openai SDK directly.  Switch
 provider by changing OPENAI_BASE_URL + OPENAI_API_KEY. That's it.
+
+For providers that are NOT OpenAI-compatible (AWS Bedrock, Google Vertex,
+etc.), use the LiteLLM backend which routes to 100+ providers through a
+single unified interface. Set CORECODER_PROVIDER=litellm.
 """
 
 import json
@@ -194,6 +198,130 @@ class LLM:
             except APIError as e:
                 # 5xx = server error, retry; 4xx = client error, don't
                 if e.status_code and e.status_code >= 500 and attempt < max_retries - 1:
+                    time.sleep(2 ** attempt)
+                else:
+                    raise
+
+
+class LiteLLM(LLM):
+    """LLM backend via LiteLLM, supporting 100+ providers.
+
+    Use this when your target provider is NOT OpenAI-compatible
+    (AWS Bedrock, Google Vertex, Cohere, etc.) or when you want
+    a single interface to switch between any provider by changing
+    the model string.
+
+    Set CORECODER_PROVIDER=litellm and use LiteLLM model strings
+    like ``anthropic/claude-3-haiku``, ``bedrock/anthropic.claude-v2``,
+    ``vertex_ai/gemini-pro``, etc.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        **kwargs,
+    ):
+        # skip LLM.__init__ which creates an OpenAI client
+        self.model = model
+        self.api_key = api_key
+        self.base_url = base_url
+        self.extra = kwargs
+        self.total_prompt_tokens = 0
+        self.total_completion_tokens = 0
+
+    def chat(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        on_token=None,
+    ) -> LLMResponse:
+        """Send messages via litellm, stream back response, handle tool calls."""
+        params: dict = {
+            "model": self.model,
+            "messages": messages,
+            "stream": True,
+            **self.extra,
+        }
+        if tools:
+            params["tools"] = tools
+
+        stream = self._call_with_retry(params)
+
+        content_parts: list[str] = []
+        tc_map: dict[int, dict] = {}
+        prompt_tok = 0
+        completion_tok = 0
+
+        for chunk in stream:
+            usage = getattr(chunk, "usage", None)
+            if usage:
+                prompt_tok = getattr(usage, "prompt_tokens", 0) or 0
+                completion_tok = getattr(usage, "completion_tokens", 0) or 0
+
+            if not getattr(chunk, "choices", None):
+                continue
+            delta = chunk.choices[0].delta
+
+            if getattr(delta, "content", None):
+                content_parts.append(delta.content)
+                if on_token:
+                    on_token(delta.content)
+
+            if getattr(delta, "tool_calls", None):
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+                    if idx not in tc_map:
+                        tc_map[idx] = {"id": "", "name": "", "args": ""}
+                    if tc_delta.id:
+                        tc_map[idx]["id"] = tc_delta.id
+                    if tc_delta.function:
+                        if tc_delta.function.name:
+                            tc_map[idx]["name"] = tc_delta.function.name
+                        if tc_delta.function.arguments:
+                            tc_map[idx]["args"] += tc_delta.function.arguments
+
+        parsed: list[ToolCall] = []
+        for idx in sorted(tc_map):
+            raw = tc_map[idx]
+            try:
+                args = json.loads(raw["args"])
+            except (json.JSONDecodeError, KeyError):
+                args = {}
+            parsed.append(ToolCall(id=raw["id"], name=raw["name"], arguments=args))
+
+        self.total_prompt_tokens += prompt_tok
+        self.total_completion_tokens += completion_tok
+
+        return LLMResponse(
+            content="".join(content_parts),
+            tool_calls=parsed,
+            prompt_tokens=prompt_tok,
+            completion_tokens=completion_tok,
+        )
+
+    def _call_with_retry(self, params: dict, max_retries: int = 3):
+        """Retry on transient errors with exponential backoff via litellm."""
+        import litellm
+
+        params["drop_params"] = True
+        if self.api_key:
+            params["api_key"] = self.api_key
+        if self.base_url:
+            params["api_base"] = self.base_url
+
+        for attempt in range(max_retries):
+            try:
+                return litellm.completion(**params)
+            except Exception as e:
+                err = str(e).lower()
+                is_transient = any(
+                    kw in err
+                    for kw in ["rate_limit", "timeout", "connection", "502", "503", "529"]
+                )
+                is_server = any(kw in err for kw in ["500", "502", "503", "504"])
+                if (is_transient or is_server) and attempt < max_retries - 1:
                     time.sleep(2 ** attempt)
                 else:
                     raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 packages = ["corecoder"]
 
 [project.optional-dependencies]
+litellm = ["litellm>=1.60.0,<2.0.0"]
 dev = ["pytest>=7.0"]
 
 [project.scripts]

--- a/tests/test_litellm.py
+++ b/tests/test_litellm.py
@@ -1,0 +1,245 @@
+"""Tests for the LiteLLM backend."""
+
+import json
+import types as builtin_types
+from unittest import mock
+
+import pytest
+
+from corecoder.llm import LLM, LiteLLM, LLMResponse, ToolCall
+from corecoder.config import Config
+
+
+# ---------------------------------------------------------------------------
+# Fake streaming response (matches OpenAI stream chunk format)
+# ---------------------------------------------------------------------------
+
+
+class _Delta:
+    def __init__(self, content=None, tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls
+
+
+class _Choice:
+    def __init__(self, delta):
+        self.delta = delta
+
+
+class _Usage:
+    def __init__(self, prompt=10, completion=5):
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+
+
+class _Chunk:
+    def __init__(self, content=None, usage=None, tool_calls=None):
+        self.choices = [_Choice(_Delta(content=content, tool_calls=tool_calls))] if content or tool_calls else []
+        self.usage = usage
+
+
+def _make_stream(contents, usage=None):
+    """Create a fake stream from a list of content strings."""
+    chunks = [_Chunk(content=c) for c in contents]
+    if usage:
+        chunks.append(_Chunk(usage=usage))
+    else:
+        chunks.append(_Chunk(usage=_Usage()))
+    return iter(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_litellm(stream_contents=None):
+    import sys
+
+    fake = builtin_types.ModuleType("litellm")
+    if stream_contents is None:
+        stream_contents = ["hello", " world"]
+    fake.completion = mock.MagicMock(
+        return_value=_make_stream(stream_contents)
+    )
+    sys.modules["litellm"] = fake
+    return fake
+
+
+def _uninstall_fake_litellm():
+    import sys
+
+    sys.modules.pop("litellm", None)
+
+
+# ---------------------------------------------------------------------------
+# LiteLLM class basics
+# ---------------------------------------------------------------------------
+
+
+class TestLiteLLMClass:
+    def test_extends_llm(self):
+        assert issubclass(LiteLLM, LLM)
+
+    def test_init_does_not_create_openai_client(self):
+        llm = LiteLLM(model="anthropic/claude-3-haiku")
+        assert not hasattr(llm, "client") or llm.__dict__.get("client") is None
+
+    def test_init_stores_model(self):
+        llm = LiteLLM(model="bedrock/anthropic.claude-v2", api_key="k")
+        assert llm.model == "bedrock/anthropic.claude-v2"
+
+    def test_init_stores_api_key(self):
+        llm = LiteLLM(model="x", api_key="sk-test")
+        assert llm.api_key == "sk-test"
+
+    def test_init_stores_base_url(self):
+        llm = LiteLLM(model="x", base_url="http://localhost:4000")
+        assert llm.base_url == "http://localhost:4000"
+
+    def test_init_stores_extra_kwargs(self):
+        llm = LiteLLM(model="x", temperature=0.7, max_tokens=2048)
+        assert llm.extra == {"temperature": 0.7, "max_tokens": 2048}
+
+    def test_token_counters_start_at_zero(self):
+        llm = LiteLLM(model="x")
+        assert llm.total_prompt_tokens == 0
+        assert llm.total_completion_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# _call_with_retry
+# ---------------------------------------------------------------------------
+
+
+class TestCallWithRetry:
+    def setup_method(self):
+        self.fake = _install_fake_litellm()
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_passes_drop_params(self):
+        llm = LiteLLM(model="openai/gpt-4o")
+        llm._call_with_retry({"model": "openai/gpt-4o", "messages": [], "stream": True})
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["drop_params"] is True
+
+    def test_forwards_api_key(self):
+        llm = LiteLLM(model="x", api_key="sk-test")
+        llm._call_with_retry({"model": "x", "messages": [], "stream": True})
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["api_key"] == "sk-test"
+
+    def test_omits_api_key_when_none(self):
+        llm = LiteLLM(model="x")
+        llm._call_with_retry({"model": "x", "messages": [], "stream": True})
+        call_kwargs = self.fake.completion.call_args[1]
+        assert "api_key" not in call_kwargs
+
+    def test_forwards_api_base(self):
+        llm = LiteLLM(model="x", base_url="http://proxy:4000")
+        llm._call_with_retry({"model": "x", "messages": [], "stream": True})
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["api_base"] == "http://proxy:4000"
+
+    def test_omits_api_base_when_none(self):
+        llm = LiteLLM(model="x")
+        llm._call_with_retry({"model": "x", "messages": [], "stream": True})
+        call_kwargs = self.fake.completion.call_args[1]
+        assert "api_base" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# chat() end-to-end (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestChat:
+    def setup_method(self):
+        self.fake = _install_fake_litellm(["part1", "part2"])
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    def test_returns_llm_response(self):
+        llm = LiteLLM(model="openai/gpt-4o")
+        result = llm.chat(messages=[{"role": "user", "content": "hi"}])
+        assert isinstance(result, LLMResponse)
+        assert result.content == "part1part2"
+
+    def test_tracks_token_usage(self):
+        llm = LiteLLM(model="openai/gpt-4o")
+        result = llm.chat(messages=[{"role": "user", "content": "hi"}])
+        assert result.prompt_tokens == 10
+        assert result.completion_tokens == 5
+        assert llm.total_prompt_tokens == 10
+        assert llm.total_completion_tokens == 5
+
+    def test_on_token_callback(self):
+        llm = LiteLLM(model="openai/gpt-4o")
+        tokens = []
+        llm.chat(
+            messages=[{"role": "user", "content": "hi"}],
+            on_token=lambda t: tokens.append(t),
+        )
+        assert tokens == ["part1", "part2"]
+
+    def test_model_forwarded(self):
+        llm = LiteLLM(model="anthropic/claude-3-haiku")
+        llm.chat(messages=[{"role": "user", "content": "hi"}])
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["model"] == "anthropic/claude-3-haiku"
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
+class TestConfigProvider:
+    def test_default_provider_is_openai(self):
+        config = Config()
+        assert config.provider == "openai"
+
+    def test_provider_from_env(self):
+        with mock.patch.dict("os.environ", {"CORECODER_PROVIDER": "litellm"}, clear=False):
+            config = Config.from_env()
+            assert config.provider == "litellm"
+
+    def test_cli_picks_litellm_class(self):
+        from corecoder.llm import LiteLLM
+        config = Config(provider="litellm", model="anthropic/claude-3-haiku", api_key="k")
+        llm_cls = LiteLLM if config.provider == "litellm" else LLM
+        assert llm_cls is LiteLLM
+
+
+# ---------------------------------------------------------------------------
+# Multi-provider model strings
+# ---------------------------------------------------------------------------
+
+
+class TestMultiProvider:
+    def setup_method(self):
+        self.fake = _install_fake_litellm(["ok"])
+
+    def teardown_method(self):
+        _uninstall_fake_litellm()
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "openai/gpt-4o",
+            "anthropic/claude-3-haiku",
+            "bedrock/anthropic.claude-v2",
+            "vertex_ai/gemini-pro",
+            "groq/llama3-70b-8192",
+            "ollama/llama3",
+            "azure/gpt-4o",
+        ],
+    )
+    def test_model_string_forwarded(self, model):
+        llm = LiteLLM(model=model)
+        llm.chat(messages=[{"role": "user", "content": "hi"}])
+        call_kwargs = self.fake.completion.call_args[1]
+        assert call_kwargs["model"] == model


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                         
                                                                                                                                                                                                                     
  - Adds `LiteLLM` class in `llm.py` extending the existing `LLM` class                                                                                                                                              
  - Gives users access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex, Groq, Cohere, Ollama, etc.) through a single unified interface                                                              
  - Users switch by setting `CORECODER_PROVIDER=litellm` and using any LiteLLM model string                                                                                                                          
  - The existing `LLM` class (OpenAI SDK) remains the default, unchanged                                                                                                                                             
                                                                                                                                                                                                                     
  ---                                                                                                                                                                                                                
                                                                                                                                                                                                                     
  - **What kind of change does this PR introduce?** Feature, adds LiteLLM as an alternative LLM backend                                                                                                              
   
  - **Why was this change needed?** CoreCoder currently supports OpenAI-compatible endpoints only. LiteLLM extends this to providers that are NOT OpenAI-compatible (AWS Bedrock, Google Vertex, Cohere, etc.)       
  through a single `completion()` call. Users switch providers by changing the model string.
                                                                                                                                                                                                                     
  - **Other information**: See sections below.        
                                                                                                                                                                            
  ---
  ## What Changed                                                                                                                                                                                                    
   
  | File | Change |                                                                                                                                                                                                  
  |---|---|       
  | `corecoder/llm.py` | Added `LiteLLM` class extending `LLM`, overriding `__init__`, `chat()`, and `_call_with_retry()` |
  | `corecoder/config.py` | Added `provider` field (default "openai", option "litellm") + `CORECODER_PROVIDER` env var |                                                                                             
  | `corecoder/cli.py` | Updated LLM instantiation to pick class based on `config.provider` |                                                                                                                        
  | `pyproject.toml` | Added `litellm>=1.60.0,<2.0.0` as optional dependency (`pip install corecoder[litellm]`) |                                                                                                    
  | `tests/test_litellm.py` | 26 unit tests |                                                                                                                                                                        
                                                                                                                                                                                                                     
  ---                                                                                                                                                                                                                
                  
  ## Usage

  ### Quick Start                                                                                                                                                                                                    
   
  ```bash                                                                                                                                                                                                            
  # Install with litellm support
  pip install corecoder[litellm]

  # Set the provider and model                                                                                                                                                                                       
  export CORECODER_PROVIDER=litellm
  export CORECODER_MODEL=anthropic/claude-3-haiku                                                                                                                                                                    
  export ANTHROPIC_API_KEY=sk-ant-...
                                                                                                                                                                                                                     
  # Run as usual
  corecoder                                                                                                                                                                                                          
                  
  Switching Providers: Just Change the Model String                                                                                                                                                                  
   
  # OpenAI (works without litellm too, via OPENAI_BASE_URL)                                                                                                                                                          
  export CORECODER_PROVIDER=litellm                                                                                                                                                                                  
  export CORECODER_MODEL=openai/gpt-4o
  export OPENAI_API_KEY=sk-...                                                                                                                                                                                       
                  
  # Anthropic                                                                                                                                                                                                        
  export CORECODER_MODEL=anthropic/claude-3-haiku
  export ANTHROPIC_API_KEY=sk-ant-...                                                                                                                                                                                
                  
  # AWS Bedrock
  export CORECODER_MODEL=bedrock/anthropic.claude-v2
  export AWS_ACCESS_KEY_ID=...                                                                                                                                                                                       
  export AWS_SECRET_ACCESS_KEY=...
                                                                                                                                                                                                                     
  # Google Vertex AI
  export CORECODER_MODEL=vertex_ai/gemini-pro
  export VERTEXAI_PROJECT=your-project                                                                                                                                                                               
   
  # Groq                                                                                                                                                                                                             
  export CORECODER_MODEL=groq/llama3-70b-8192
  export GROQ_API_KEY=gsk_...                                                                                                                                                                                        
   
  # Local Ollama                                                                                                                                                                                                     
  export CORECODER_MODEL=ollama/llama3
```
  Any of the https://docs.litellm.ai/docs/providers works.                                                                                                                                                           
   
  ### Programmatic Usage                                                                                                                                                                                                 
```python                  
  from corecoder.llm import LiteLLM

  llm = LiteLLM(
      model="anthropic/claude-3-haiku",
      # api_key is optional, litellm reads env vars automatically                                                                                                                                                    
  )
                                                                                                                                                                                                                     
  result = llm.chat(                                                                                                                                                                                                 
      messages=[{"role": "user", "content": "What is 2+2?"}],
      on_token=lambda t: print(t, end="", flush=True),                                                                                                                                                               
  )               
  print(result.content)                                                                                                                                                                                              
 ```  
  ---                                                                                                                                                                                                                
  ## Testing         
         
  ### Unit Tests (26/26 Passing)
  ```                                                                                                                                                                                                                   
  tests/test_litellm.py::TestLiteLLMClass::test_extends_llm PASSED
  tests/test_litellm.py::TestLiteLLMClass::test_init_does_not_create_openai_client PASSED                                                                                                                            
  tests/test_litellm.py::TestLiteLLMClass::test_init_stores_model PASSED                                                                                                                                             
  tests/test_litellm.py::TestLiteLLMClass::test_init_stores_api_key PASSED
  tests/test_litellm.py::TestLiteLLMClass::test_init_stores_base_url PASSED                                                                                                                                          
  tests/test_litellm.py::TestLiteLLMClass::test_init_stores_extra_kwargs PASSED                                                                                                                                      
  tests/test_litellm.py::TestLiteLLMClass::test_token_counters_start_at_zero PASSED
  tests/test_litellm.py::TestCallWithRetry::test_passes_drop_params PASSED                                                                                                                                           
  tests/test_litellm.py::TestCallWithRetry::test_forwards_api_key PASSED
  tests/test_litellm.py::TestCallWithRetry::test_omits_api_key_when_none PASSED                                                                                                                                      
  tests/test_litellm.py::TestCallWithRetry::test_forwards_api_base PASSED
  tests/test_litellm.py::TestCallWithRetry::test_omits_api_base_when_none PASSED                                                                                                                                     
  tests/test_litellm.py::TestChat::test_returns_llm_response PASSED
  tests/test_litellm.py::TestChat::test_tracks_token_usage PASSED                                                                                                                                                    
  tests/test_litellm.py::TestChat::test_on_token_callback PASSED
  tests/test_litellm.py::TestChat::test_model_forwarded PASSED                                                                                                                                                       
  tests/test_litellm.py::TestConfigProvider::test_default_provider_is_openai PASSED                                                                                                                                  
  tests/test_litellm.py::TestConfigProvider::test_provider_from_env PASSED
  tests/test_litellm.py::TestConfigProvider::test_cli_picks_litellm_class PASSED                                                                                                                                     
  tests/test_litellm.py::TestMultiProvider::test_model_string_forwarded[openai/gpt-4o] PASSED                                                                                                                        
  tests/test_litellm.py::TestMultiProvider::test_model_string_forwarded[anthropic/claude-3-haiku] PASSED
  tests/test_litellm.py::TestMultiProvider::test_model_string_forwarded[bedrock/anthropic.claude-v2] PASSED                                                                                                          
  tests/test_litellm.py::TestMultiProvider::test_model_string_forwarded[vertex_ai/gemini-pro] PASSED                                                                                                                 
  tests/test_litellm.py::TestMultiProvider::test_model_string_forwarded[groq/llama3-70b-8192] PASSED                                                                                                                 
  tests/test_litellm.py::TestMultiProvider::test_model_string_forwarded[ollama/llama3] PASSED                                                                                                                        
  tests/test_litellm.py::TestMultiProvider::test_model_string_forwarded[azure/gpt-4o] PASSED
  ============================== 26 passed in 0.23s ==============================                                                                                                                                   
  ```                                                                                                                                                                                                                   
  ### E2E  Tests(Azure AI Foundry, Claude Sonnet via LiteLLM)                                                                                                                                                             
  ```                                                                                                                                                                                                                   
  Model: azure_ai/claude-sonnet-4-6                                                                                                                                                                                  
                  
  --- E2E 1: Basic streaming chat ---                                                                                                                                                                                
  Prompt: "What is 2+2? Reply with just the number."
  Response: "4"                                                                                                                                                                                                      
  Streamed tokens: ["4"]

  --- E2E 2: Multi-turn conversation ---                                                                                                                                                                             
  Messages:
    system: "You are a math tutor. Be very brief."                                                                                                                                                                   
    user: "What is 10 * 5?"
    assistant: "50"
    user: "Divide that by 2"                                                                                                                                                                                         
  Response: "25"
                                                                                                                                                                                                                     
  --- E2E 3: Config provider selection ---
  Config.provider=litellm selects LiteLLM class: True
                                                                                                                                                                                                                     
  --- E2E 4: Error handling (invalid model) ---
  Model: nonexistent/bad-model                                                                                                                                                                                       
  Caught expected error: BadRequestError
  "LLM Provider NOT provided. Pass in the LLM provider you are trying to call."
   ```                                                                                                                                                                                                                                                                                                                                                           
  ---             
  Risk / Compatibility
                      
  - Additive only, existing LLM class unchanged
  - LiteLLM is an optional dependency (pip install corecoder[litellm]), not required for default usage                                                                                                               
  - drop_params=True set by default so provider-unsupported kwargs are silently dropped                                                                                                                              
  - Default provider remains "openai", LiteLLM only activates when CORECODER_PROVIDER=litellm                                                                                                                        
