### PR TITLE
Add MiniMax-M3 provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Give it a model and a key and it goes. It speaks the OpenAI-compatible API by de
 |---|---|
 | OpenAI (default `gpt-5.5`) | `OPENAI_API_KEY=sk-...` |
 | DeepSeek | `OPENAI_API_KEY=sk-... OPENAI_BASE_URL=https://api.deepseek.com CORECODER_MODEL=deepseek-chat` |
+| MiniMax | `OPENAI_API_KEY=sk-... OPENAI_BASE_URL=https://api.minimax.io/v1 CORECODER_MODEL=MiniMax-M3` |
 | Local Ollama | `OPENAI_API_KEY=ollama OPENAI_BASE_URL=http://localhost:11434/v1 CORECODER_MODEL=qwen2.5-coder` |
 
 Kimi, Qwen and the like are the same two variables; for providers that don't even offer an OpenAI-compatible endpoint, the optional LiteLLM backend (`pip install "corecoder[litellm]"`) routes to a hundred-plus of them. The third essay goes into this in detail. The key can be `export`ed directly or dropped into a `.env` at the project root, which is loaded on startup. Then:

--- a/README_CN.md
+++ b/README_CN.md
@@ -69,6 +69,7 @@ pip install -e .
 |---|---|
 | OpenAI（默认 `gpt-5.5`） | `OPENAI_API_KEY=sk-...` |
 | DeepSeek | `OPENAI_API_KEY=sk-... OPENAI_BASE_URL=https://api.deepseek.com CORECODER_MODEL=deepseek-chat` |
+| MiniMax | `OPENAI_API_KEY=sk-... OPENAI_BASE_URL=https://api.minimax.io/v1 CORECODER_MODEL=MiniMax-M3` |
 | 本地 Ollama | `OPENAI_API_KEY=ollama OPENAI_BASE_URL=http://localhost:11434/v1 CORECODER_MODEL=qwen2.5-coder` |
 
 Kimi、Qwen 这些同样是改这两个变量；连 OpenAI 兼容接口都不给的 provider，装上可选的 LiteLLM 后端（`pip install "corecoder[litellm]"`）能路由一百多家。第三篇文章把这块讲得更细。key 可以直接 `export`，也可以在项目根目录扔个 `.env`，启动时自动加载。然后：

--- a/corecoder/llm.py
+++ b/corecoder/llm.py
@@ -78,6 +78,8 @@ _PRICING = {
     "qwen-max": (0.78, 3.9),
     # Moonshot Kimi
     "kimi-k2.5": (0.6, 3),
+    # MiniMax
+    "MiniMax-M3": (0.6, 2.4),
 }
 
 


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax-M3 to the built-in pricing table for cost estimates.
- Document the MiniMax OpenAI-compatible endpoint in the English and Chinese provider examples.

## Checks
- `git add -A -N && if git diff HEAD | grep -E "$SECRET_RE"; then echo secret_scan_failed; exit 1; fi`
- `python3 -m compileall corecoder`

Not run: `python3 -m pytest tests/test_litellm.py` (pytest is not installed); `python3 -m pip install -e '.[dev]'` (pip is not installed in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)