### PR TITLE
docs: add OmniRoute provider examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Give it a model and a key and it goes. It speaks the OpenAI-compatible API by de
 |---|---|
 | OpenAI (default `gpt-5.5`) | `OPENAI_API_KEY=sk-...` |
 | DeepSeek | `OPENAI_API_KEY=sk-... OPENAI_BASE_URL=https://api.deepseek.com CORECODER_MODEL=deepseek-chat` |
+| OmniRoute | `OPENAI_API_KEY=your-key OPENAI_BASE_URL=http://localhost:20128/v1 CORECODER_MODEL=auto` |
 | Local Ollama | `OPENAI_API_KEY=ollama OPENAI_BASE_URL=http://localhost:11434/v1 CORECODER_MODEL=qwen2.5-coder` |
 
 Kimi, Qwen and the like are the same two variables; for providers that don't even offer an OpenAI-compatible endpoint, the optional LiteLLM backend (`pip install "corecoder[litellm]"`) routes to a hundred-plus of them. The third essay goes into this in detail. The key can be `export`ed directly or dropped into a `.env` at the project root, which is loaded on startup. Then:

--- a/README_CN.md
+++ b/README_CN.md
@@ -69,6 +69,7 @@ pip install -e .
 |---|---|
 | OpenAI（默认 `gpt-5.5`） | `OPENAI_API_KEY=sk-...` |
 | DeepSeek | `OPENAI_API_KEY=sk-... OPENAI_BASE_URL=https://api.deepseek.com CORECODER_MODEL=deepseek-chat` |
+| OmniRoute | `OPENAI_API_KEY=your-key OPENAI_BASE_URL=http://localhost:20128/v1 CORECODER_MODEL=auto` |
 | 本地 Ollama | `OPENAI_API_KEY=ollama OPENAI_BASE_URL=http://localhost:11434/v1 CORECODER_MODEL=qwen2.5-coder` |
 
 Kimi、Qwen 这些同样是改这两个变量；连 OpenAI 兼容接口都不给的 provider，装上可选的 LiteLLM 后端（`pip install "corecoder[litellm]"`）能路由一百多家。第三篇文章把这块讲得更细。key 可以直接 `export`，也可以在项目根目录扔个 `.env`，启动时自动加载。然后：


### PR DESCRIPTION
## Summary

Document OmniRoute in the existing OpenAI-compatible provider examples.

## What changed

- Add the OmniRoute local gateway configuration to the English README.
- Add the same configuration to the Chinese README.
- Use CoreCoder's existing `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and
  `CORECODER_MODEL` configuration without introducing provider-specific code.

The documented setup routes CoreCoder through
`http://localhost:20128/v1` with the OmniRoute `auto` model.

## Validation

- `python -m pytest tests/ -q` - 86 passed.
- `python -m compileall -q corecoder tests` - passed.
- `python -m build` - passed.
- `python -m twine check <temporary-dist>/*` - passed for the wheel and sdist.
- `git diff --check` - passed.
- Sanitized local smoke - confirmed Bearer authentication,
  `POST /v1/chat/completions`, `model: auto`, streaming, function tool schemas,
  and streamed tool-call reconstruction.

`ruff check corecoder tests` continues to report the same 41 pre-existing
violations from the upstream baseline; this documentation-only change does not
add or modify Python code.
